### PR TITLE
feat(question-service): 实现MBTI题库两层随机抽取

### DIFF
--- a/cloudfunctions/getQuestions/index.js
+++ b/cloudfunctions/getQuestions/index.js
@@ -1,0 +1,368 @@
+const cloud = require('wx-server-sdk')
+cloud.init({ env: cloud.DYNAMIC_CURRENT_ENV })
+const db = cloud.database()
+
+// ======================== 参数验证函数 ========================
+
+/**
+ * 校验并归一化 count 参数（抽题数量）
+ * - 不传 → 默认5
+ * - 非正整数（含0、负数、浮点数、非数字、Infinity） → 重置为5
+ * - 正整数 < 3 → 返回 null（调用方应返回 INVALID_COUNT 错误）
+ * - 正整数 >= 3 → 保持原值
+ * @param {*} count - 传入的抽题数量参数
+ * @returns {number|null} 归一化后的数量，null 表示应报错
+ */
+function sanitizeCount(count) {
+  // 未传参时使用默认值
+  if (count === undefined || count === null) {
+    return 5
+  }
+  // 非数字、非有限数、非正整数（含0、负数、浮点数）均重置为默认值
+  if (typeof count !== 'number' || !Number.isFinite(count) || !Number.isInteger(count) || count <= 0) {
+    return 5
+  }
+  // 正整数但小于3，返回 null 表示需要报错 INVALID_COUNT
+  if (count < 3) {
+    return null
+  }
+  return count
+}
+
+/**
+ * 校验并归一化 optionsPerQuestion 参数（每题选项数）
+ * - 不传 → 默认3
+ * - -1 或 null → 返回 -1（表示返回全部选项）
+ * - 非正整数（含0、负数、浮点数、非数字，-1除外） → 重置为3
+ * - 正整数 < 3 → 重置为3
+ * - 正整数 >= 3 → 保持原值
+ * @param {*} optionsPerQuestion - 传入的每题选项数参数
+ * @returns {number} 归一化后的选项数，-1 表示返回全部
+ */
+function sanitizeOptions(optionsPerQuestion) {
+  // 未传参时使用默认值
+  if (optionsPerQuestion === undefined) {
+    return 3
+  }
+  // null 或 -1 表示返回全部选项
+  if (optionsPerQuestion === null || optionsPerQuestion === -1) {
+    return -1
+  }
+  // 非数字、非有限数、非整数均重置为默认值
+  if (typeof optionsPerQuestion !== 'number' || !Number.isFinite(optionsPerQuestion) || !Number.isInteger(optionsPerQuestion)) {
+    return 3
+  }
+  // 非正整数（含0和负数）重置为默认值
+  if (optionsPerQuestion <= 0) {
+    return 3
+  }
+  // 正整数但小于3，重置为3
+  if (optionsPerQuestion < 3) {
+    return 3
+  }
+  return optionsPerQuestion
+}
+
+// ======================== 工具函数 ========================
+
+/**
+ * 云数据库分页查询工具，每批最多100条
+ * 显式 orderBy('_id', 'asc') 保证分页一致性
+ * @param {object} db - 云数据库实例
+ * @param {string} collection - 集合名称
+ * @param {object} filter - 查询条件（where 条件对象）
+ * @returns {Promise<Array>} 查询到的全部记录
+ */
+async function fetchAll(db, collection, filter) {
+  const PAGE_SIZE = 100
+  let allData = []
+  let offset = 0
+
+  // 首批查询，失败直接抛出
+  const firstBatch = await db.collection(collection)
+    .where(filter)
+    .orderBy('_id', 'asc')
+    .skip(offset)
+    .limit(PAGE_SIZE)
+    .get()
+
+  allData = allData.concat(firstBatch.data)
+
+  // 如果首批数据不足一页，说明已全部获取
+  if (firstBatch.data.length < PAGE_SIZE) {
+    return allData
+  }
+
+  // 后续批次循环查询
+  offset += PAGE_SIZE
+  while (true) {
+    try {
+      const batch = await db.collection(collection)
+        .where(filter)
+        .orderBy('_id', 'asc')
+        .skip(offset)
+        .limit(PAGE_SIZE)
+        .get()
+
+      allData = allData.concat(batch.data)
+
+      // 当前批次不足一页，说明已全部获取
+      if (batch.data.length < PAGE_SIZE) {
+        break
+      }
+      offset += PAGE_SIZE
+    } catch (err) {
+      // 后续批次失败记录错误但继续，返回已获取的数据
+      console.error(`分页查询第 ${offset / PAGE_SIZE + 1} 批次失败:`, err)
+      break
+    }
+  }
+
+  return allData
+}
+
+/**
+ * Fisher-Yates 部分洗牌算法，从数组中随机抽取指定数量的元素
+ * @param {Array} array - 原始数组
+ * @param {number} count - 需要抽取的数量
+ * @returns {Array} 随机抽取的元素数组
+ */
+function shufflePick(array, count) {
+  const copy = [...array]
+  // 入参防御：防止负数导致异常
+  const pickCount = Math.min(Math.max(0, count), copy.length)
+
+  if (pickCount === 0) {
+    return []
+  }
+
+  // Fisher-Yates 部分洗牌：从末尾开始交换，只洗 pickCount 个位置
+  // 循环条件修复 off-by-one：i >= copy.length - pickCount
+  for (let i = copy.length - 1; i >= copy.length - pickCount; i--) {
+    // 生成 [0, i] 范围内的随机索引
+    const j = Math.floor(Math.random() * (i + 1))
+    // 交换当前位置与随机位置的元素
+    ;[copy[i], copy[j]] = [copy[j], copy[i]]
+  }
+
+  // 返回末尾 pickCount 个已洗牌的元素
+  return copy.slice(copy.length - pickCount)
+}
+
+/**
+ * 生成选项编号
+ * - index < 26: 返回 A-Z 单字母
+ * - index >= 26: 返回 AA, AB, AC... 双字母编号
+ * @param {number} index - 选项索引（从0开始）
+ * @returns {string} 选项编号
+ */
+function generateOptionId(index) {
+  if (index < 26) {
+    // 单字母编号：A-Z
+    return String.fromCharCode(65 + index)
+  }
+  // 双字母编号：AA, AB, AC...
+  const firstLetter = String.fromCharCode(65 + Math.floor((index - 26) / 26))
+  const secondLetter = String.fromCharCode(65 + ((index - 26) % 26))
+  return firstLetter + secondLetter
+}
+
+/**
+ * 从题目选项中随机抽取指定数量的选项
+ * - optionsPerQuestion 为 -1 或 null 时返回全部选项
+ * - 否则抽取 min(requested, options.length) 个
+ * - 抽取后按原始 id 升序排列，然后重新编号为 A, B, C...
+ * - 检测 option_shortage 并返回 warning
+ * @param {Array} options - 题目的全部选项
+ * @param {number} optionsPerQuestion - 需要的选项数，-1 表示全部
+ * @returns {{ options: Array, warning: string|null }} 抽取后的选项及可能的警告
+ */
+function pickRandomOptions(options, optionsPerQuestion) {
+  // -1 或 null 表示返回全部选项
+  if (optionsPerQuestion === -1 || optionsPerQuestion === null) {
+    // 全部返回时也重新编号
+    const allOptions = options.map((opt, idx) => ({
+      ...opt,
+      id: generateOptionId(idx)
+    }))
+    return { options: allOptions, warning: null }
+  }
+
+  let warning = null
+  // 实际可抽取的数量取请求数和可用数的较小值
+  const actualPick = Math.min(optionsPerQuestion, options.length)
+
+  // 检测选项不足的情况
+  if (options.length < optionsPerQuestion) {
+    warning = `选项不足：请求 ${optionsPerQuestion} 个，实际只有 ${options.length} 个`
+  }
+
+  // 随机抽取选项
+  const picked = shufflePick(options, actualPick)
+
+  // 按原始 id 升序排列，保持选项顺序一致性
+  picked.sort((a, b) => {
+    if (a.id < b.id) return -1
+    if (a.id > b.id) return 1
+    return 0
+  })
+
+  // 重新编号为 A, B, C...
+  const renumbered = picked.map((opt, idx) => ({
+    ...opt,
+    id: generateOptionId(idx)
+  }))
+
+  return { options: renumbered, warning }
+}
+
+// ======================== 主函数 ========================
+
+/**
+ * 题库两层随机抽取主函数
+ * 1. 参数验证与归一化
+ * 2. 查询有效题目并过滤
+ * 3. 第一层随机：抽取题目
+ * 4. 第二层随机：每题抽取选项
+ * 5. 返回标准结构
+ *
+ * 错误码说明：
+ * - INVALID_COUNT: count 为正整数但小于3时触发
+ * - INVALID_CATEGORY: category 类型不是 string 也不是 null/undefined 时触发
+ * - EMPTY_BANK: 没有可用题目时触发
+ * - CLOUD_FUNCTION_ERROR: 未捕获的异常时触发（在入口处处理）
+ *
+ * @param {object} event - 云函数调用参数
+ * @param {number} [event.count=5] - 抽题数量
+ * @param {number} [event.optionsPerQuestion=3] - 每题选项数，-1 表示全部
+ * @param {string|null} [event.category] - 题目分类筛选
+ * @returns {Promise<object>} 标准返回结构
+ */
+async function getQuestions(event) {
+  const warnings = []
+
+  // ---- 1. 参数验证与归一化 ----
+  const count = sanitizeCount(event.count)
+  // count 为 null 表示正整数但小于3，需要报错
+  if (count === null) {
+    return {
+      success: false,
+      data: null,
+      warnings: [],
+      error: { code: 'INVALID_COUNT', message: 'count必须为大于等于3的正整数' }
+    }
+  }
+
+  const optionsPerQuestion = sanitizeOptions(event.optionsPerQuestion)
+
+  // ---- 2. category 类型验证 ----
+  let category = event.category
+
+  // category 只接受 string 或 null/undefined
+  if (category !== undefined && category !== null && typeof category !== 'string') {
+    return {
+      success: false,
+      data: null,
+      warnings: [],
+      error: { code: 'INVALID_CATEGORY', message: 'category 必须为字符串或 null' }
+    }
+  }
+
+  // 空字符串（含纯空白）视为 null（不筛选分类）
+  if (category === undefined || (typeof category === 'string' && category.trim() === '')) {
+    category = null
+  }
+
+  // ---- 3. 构建查询条件并获取题目 ----
+  const filter = { isActive: true }
+  if (category !== null) {
+    filter.category = category
+  }
+
+  const allQuestions = await fetchAll(db, 'questions', filter)
+
+  // 二次过滤：确保每题至少有3个选项
+  const validQuestions = allQuestions.filter(q =>
+    Array.isArray(q.options) && q.options.length >= 3
+  )
+
+  // ---- 4. 题库为空检查 ----
+  if (validQuestions.length === 0) {
+    return {
+      success: false,
+      data: null,
+      warnings: [],
+      error: { code: 'EMPTY_BANK', message: '题库为空或没有符合条件的题目' }
+    }
+  }
+
+  // ---- 5. 动态边界计算 ----
+  const actualCount = Math.min(count, validQuestions.length)
+
+  // 收集题目不足警告
+  if (validQuestions.length < count) {
+    warnings.push({
+      type: 'insufficient_questions',
+      message: `请求 ${count} 题，题库仅有 ${validQuestions.length} 题，已全部返回`
+    })
+  }
+
+  // ---- 6. 第一层随机：抽取题目 ----
+  const pickedQuestions = shufflePick(validQuestions, actualCount)
+
+  // ---- 7. 第二层随机：每题抽取选项 ----
+  const resultQuestions = pickedQuestions.map(q => {
+    const { options, warning } = pickRandomOptions(q.options, optionsPerQuestion)
+
+    // 收集选项不足警告
+    if (warning) {
+      warnings.push({
+        type: 'option_shortage',
+        questionId: q._id,
+        message: warning
+      })
+    }
+
+    return {
+      _id: q._id,
+      question: q.question,
+      category: q.category || null,
+      options
+    }
+  })
+
+  // ---- 8. 构建并返回标准结构 ----
+  return {
+    success: true,
+    data: {
+      questions: resultQuestions,
+      meta: {
+        total: validQuestions.length,
+        requested: count,
+        actual: actualCount,
+        // -1 时标记为 'all'
+        requestedOptionsPerQuestion: optionsPerQuestion === -1 ? 'all' : optionsPerQuestion,
+        category: category,
+        source: 'cloud'
+      }
+    },
+    warnings,
+    error: null
+  }
+}
+
+// ======================== 云函数入口 ========================
+
+exports.main = async (event, context) => {
+  try {
+    return await getQuestions(event)
+  } catch (e) {
+    console.error('云函数执行异常:', e)
+    return {
+      success: false,
+      data: null,
+      warnings: [],
+      error: { code: 'CLOUD_FUNCTION_ERROR', message: '服务异常，请稍后重试' }
+    }
+  }
+}

--- a/cloudfunctions/getQuestions/index.js
+++ b/cloudfunctions/getQuestions/index.js
@@ -230,12 +230,14 @@ function pickRandomOptions(options, optionsPerQuestion) {
  * - INVALID_COUNT: count 为正整数但小于3时触发
  * - INVALID_CATEGORY: category 类型不是 string 也不是 null/undefined 时触发
  * - EMPTY_BANK: 没有可用题目时触发
+ * - EXCLUDED_EMPTY: 排除 excludeCategories 后题库无可用题目时触发
  * - CLOUD_FUNCTION_ERROR: 未捕获的异常时触发（在入口处处理）
  *
  * @param {object} event - 云函数调用参数
  * @param {number} [event.count=5] - 抽题数量
  * @param {number} [event.optionsPerQuestion=3] - 每题选项数，-1 表示全部
  * @param {string|null} [event.category] - 题目分类筛选
+ * @param {string[]} [event.excludeCategories] - 需排除的侧重点列表（续写去重用）
  * @returns {Promise<object>} 标准返回结构
  */
 async function getQuestions(event) {
@@ -273,6 +275,22 @@ async function getQuestions(event) {
     category = null
   }
 
+  // ---- excludeCategories 参数验证（续写去重） ----
+  let excludeCategories = event.excludeCategories
+  // 只接受数组，非数组视为无排除
+  if (excludeCategories !== undefined && excludeCategories !== null) {
+    if (!Array.isArray(excludeCategories)) {
+      excludeCategories = []
+    } else {
+      // 过滤掉非字符串元素，去重
+      excludeCategories = [...new Set(
+        excludeCategories.filter(c => typeof c === 'string' && c.trim() !== '')
+      )]
+    }
+  } else {
+    excludeCategories = []
+  }
+
   // ---- 3. 构建查询条件并获取题目 ----
   const filter = { isActive: true }
   if (category !== null) {
@@ -296,21 +314,51 @@ async function getQuestions(event) {
     }
   }
 
-  // ---- 5. 动态边界计算 ----
-  const actualCount = Math.min(count, validQuestions.length)
+  // ---- 5. 按 excludeCategories 过滤（跨轮续写去重） ----
+  let availableQuestions = validQuestions
+  if (excludeCategories.length > 0) {
+    const excludedSet = new Set(excludeCategories)
+    availableQuestions = validQuestions.filter(q => !excludedSet.has(q.category))
+    // 排除后题库为空
+    if (availableQuestions.length === 0) {
+      return {
+        success: false,
+        data: null,
+        warnings: [],
+        error: { code: 'EXCLUDED_EMPTY', message: '排除已答分类后，题库无可用题目' }
+      }
+    }
+  }
+
+  // ---- 6. 侧重点去重：按 category 分组，每组随机取一题 ----
+  // 保证同一批次内抽取的题目 category 均不相同
+  function pickDistinctCategories(questions) {
+    const grouped = {}
+    for (const q of questions) {
+      const cat = q.category || '__uncategorized__'
+      if (!grouped[cat]) grouped[cat] = []
+      grouped[cat].push(q)
+    }
+    return Object.values(grouped).map(group => shufflePick(group, 1)[0])
+  }
+
+  const distinctQuestions = pickDistinctCategories(availableQuestions)
+
+  // ---- 7. 动态边界计算 ----
+  const actualCount = Math.min(count, distinctQuestions.length)
 
   // 收集题目不足警告
-  if (validQuestions.length < count) {
+  if (distinctQuestions.length < count) {
     warnings.push({
       type: 'insufficient_questions',
-      message: `请求 ${count} 题，题库仅有 ${validQuestions.length} 题，已全部返回`
+      message: `请求 ${count} 题，去除已答分类后仅有 ${distinctQuestions.length} 个不同侧重点，已全部返回`
     })
   }
 
-  // ---- 6. 第一层随机：抽取题目 ----
-  const pickedQuestions = shufflePick(validQuestions, actualCount)
+  // ---- 8. 第一层随机：从侧重点去重后的列表中抽取题目 ----
+  const pickedQuestions = shufflePick(distinctQuestions, actualCount)
 
-  // ---- 7. 第二层随机：每题抽取选项 ----
+  // ---- 9. 第二层随机：每题抽取选项 ----
   const resultQuestions = pickedQuestions.map(q => {
     const { options, warning } = pickRandomOptions(q.options, optionsPerQuestion)
 
@@ -331,7 +379,7 @@ async function getQuestions(event) {
     }
   })
 
-  // ---- 8. 构建并返回标准结构 ----
+  // ---- 10. 构建并返回标准结构 ----
   return {
     success: true,
     data: {
@@ -343,6 +391,7 @@ async function getQuestions(event) {
         // -1 时标记为 'all'
         requestedOptionsPerQuestion: optionsPerQuestion === -1 ? 'all' : optionsPerQuestion,
         category: category,
+        excludedCategoriesCount: excludeCategories.length,
         source: 'cloud'
       }
     },

--- a/cloudfunctions/getQuestions/package.json
+++ b/cloudfunctions/getQuestions/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "getQuestions",
+  "version": "1.0.0",
+  "description": "题库两层随机抽取云函数",
+  "main": "index.js",
+  "dependencies": {
+    "wx-server-sdk": "~2.6.3"
+  },
+  "config": {
+    "timeout": 10
+  }
+}

--- a/miniprogram/config.js
+++ b/miniprogram/config.js
@@ -10,12 +10,11 @@ const config = {
   host,
 
   // 云开发环境 ID
-  envId: 'release-b86096',
-  // envId: 'test-f0b102',
+  envId: 'cloud1-2gj8viqpaf4a9ff5',
 
   // 云开发-存储 示例文件的文件 ID
-  demoImageFileId: 'cloud://release-b86096.7265-release-b86096-1258211818/demo.jpg',
-  demoVideoFileId: 'cloud://release-b86096.7265-release-b86096/demo.mp4',
+  demoImageFileId: 'cloud://cloud1-2gj8viqpaf4a9ff5.636c-cloud1-2gj8viqpaf4a9ff5-1409286421/demo.jpg',
+  demoVideoFileId: 'cloud://cloud1-2gj8viqpaf4a9ff5.636c-cloud1-2gj8viqpaf4a9ff5/demo.mp4',
 }
 
 module.exports = config

--- a/miniprogram/services/question-service.js
+++ b/miniprogram/services/question-service.js
@@ -78,6 +78,8 @@ class QuestionService {
     this._cache = new Map()
     /** @type {number} 缓存有效期，5分钟 */
     this._CACHE_TTL = 5 * 60 * 1000
+    /** @type {Set<string>} 已见侧重点集合，跨轮续写时自动追踪，无需前端手动管理 */
+    this._seenCategories = new Set()
   }
 
   /**
@@ -89,6 +91,7 @@ class QuestionService {
    * @returns {Object} 验证结果
    * - 验证失败：{ error: { code: 'INVALID_COUNT', message: '...' } }
    * - 验证通过：{ count, optionsPerQuestion, category }
+   * @description excludeCategories 不再从外部接收，由服务层内部通过 _seenCategories 自动管理
    */
   _sanitizeParams(params = {}) {
     // 校验 count 参数
@@ -121,15 +124,19 @@ class QuestionService {
 
   /**
    * 根据参数组合生成缓存键
-   * @param {Object} params - 已校验的参数
+   * @param {Object} params - 已校验的参数（含内部 excludeCategories）
    * @param {number} params.count - 题目数量
    * @param {number} params.optionsPerQuestion - 每题选项数
    * @param {string|null} params.category - 题目分类
-   * @returns {string} 缓存键，格式：count_optionsPerQuestion_category
+   * @param {string[]|null} params.excludeCategories - 排除的侧重点列表（由内部 _seenCategories 自动生成）
+   * @returns {string} 缓存键，格式：count_optionsPerQuestion_category_exclude_xxx
    */
   _getCacheKey(params) {
-    const { count, optionsPerQuestion, category } = params
-    return `${count}_${optionsPerQuestion}_${category || 'all'}`
+    const { count, optionsPerQuestion, category, excludeCategories } = params
+    const excludeKey = Array.isArray(excludeCategories) && excludeCategories.length > 0
+      ? [...excludeCategories].sort().join(',')
+      : 'none'
+    return `${count}_${optionsPerQuestion}_${category || 'all'}_exclude_${excludeKey}`
   }
 
   /**
@@ -195,7 +202,7 @@ class QuestionService {
 
   /**
    * 获取随机MBTI题目（主入口方法）
-   * 流程：参数验证 → 查缓存 → 调用云函数 → 缓存成功结果 → 返回
+   * 流程：参数验证 → 合并已见侧重点 → 查缓存 → 调用云函数 → 追踪侧重点 → 缓存成功结果 → 返回
    * @param {Object} [params={}] - 请求参数
    * @param {number} [params.count] - 题目数量，默认5，最小3
    * @param {number} [params.optionsPerQuestion] - 每题选项数，默认3，-1表示全部
@@ -204,9 +211,15 @@ class QuestionService {
    * - 成功：云函数返回的数据
    * - 参数错误：{ success: false, error: { code: 'INVALID_COUNT', message: '...' } }
    * - 网络/云函数错误：{ success: false, error: { code: 'CLOUD_FUNCTION_ERROR', message: '网络异常，请重试' } }
+   * @description
+   * 侧重点去重完全在 API 内部自动完成：
+   * - 每次成功获取题目后，自动将返回题目的 category 加入 _seenCategories
+   * - 下次调用时自动将 _seenCategories 作为 excludeCategories 传给云函数
+   * - 前端无需传 excludeCategories，也无需手动收集已答 category
+   * - 开始新一轮测试前调用 resetSession() 清空已见集合
    */
   async getRandomQuestions(params = {}) {
-    // 第一步：参数验证
+    // 第一步：参数验证（不含 excludeCategories，由内部自动管理）
     const sanitized = this._sanitizeParams(params)
 
     // 参数验证失败（如 count < 3），提前返回错误
@@ -214,23 +227,37 @@ class QuestionService {
       return { success: false, error: sanitized.error }
     }
 
-    // 第二步：查询缓存
-    const cachedResult = this._getCachedResult(sanitized)
+    // 第二步：合并内部已见侧重点，构建传给云函数的完整参数
+    const cloudParams = {
+      ...sanitized,
+      excludeCategories: this._seenCategories.size > 0 ? [...this._seenCategories] : null
+    }
+
+    // 第三步：查询缓存
+    const cachedResult = this._getCachedResult(cloudParams)
     if (cachedResult) {
+      // 命中缓存时仍需追踪返回题目的侧重点
+      if (cachedResult.success && cachedResult.data && cachedResult.data.questions) {
+        cachedResult.data.questions.forEach(q => this._seenCategories.add(q.category))
+      }
       return cachedResult
     }
 
-    // 第三步：调用云函数获取题目
+    // 第四步：调用云函数获取题目
     try {
       const result = await this._callCloudFunction('getQuestions', {
-        count: sanitized.count,
-        optionsPerQuestion: sanitized.optionsPerQuestion,
-        category: sanitized.category
+        count: cloudParams.count,
+        optionsPerQuestion: cloudParams.optionsPerQuestion,
+        category: cloudParams.category,
+        excludeCategories: cloudParams.excludeCategories
       })
 
-      // 第四步：只缓存成功结果，不缓存错误
+      // 第五步：追踪成功返回题目的侧重点 + 缓存
       if (result && result.success) {
-        this._cacheResult(sanitized, result)
+        if (result.data && result.data.questions) {
+          result.data.questions.forEach(q => this._seenCategories.add(q.category))
+        }
+        this._cacheResult(cloudParams, result)
       }
 
       return result
@@ -245,6 +272,15 @@ class QuestionService {
         }
       }
     }
+  }
+
+  /**
+   * 重置会话状态，清空已见侧重点集合
+   * @description 开始新一轮完整测试时调用，让 API 重新从全量题库中抽取
+   * 注意：不会清空缓存，仅清空 _seenCategories
+   */
+  resetSession() {
+    this._seenCategories.clear()
   }
 }
 

--- a/miniprogram/services/question-service.js
+++ b/miniprogram/services/question-service.js
@@ -1,0 +1,253 @@
+/**
+ * @file question-service.js
+ * @description MBTI题目服务层，负责随机题目的获取、参数校验与缓存管理
+ */
+
+/**
+ * 校验并修正 count 参数
+ * @param {*} count - 题目数量参数
+ * @returns {number|null} 修正后的数值；null 表示应报错 INVALID_COUNT
+ * - 不传/undefined → 默认5
+ * - 非正整数（含0、负数、浮点数、非数字、Infinity） → 重置为5
+ * - 正整数 < 3 → 返回 null（触发 INVALID_COUNT 错误码）
+ * - 正整数 >= 3 → 保持原值
+ */
+function sanitizeCount(count) {
+  // 未传参时使用默认值
+  if (count === undefined || count === null) {
+    return 5
+  }
+
+  // 判断是否为正整数（排除 Infinity、NaN、浮点数、非数字类型）
+  if (typeof count !== 'number' || !Number.isFinite(count) || !Number.isInteger(count) || count <= 0) {
+    return 5
+  }
+
+  // 正整数但小于3，按决策规范应报错而非重置
+  if (count < 3) {
+    return null
+  }
+
+  return count
+}
+
+/**
+ * 校验并修正 optionsPerQuestion 参数
+ * @param {*} optionsPerQuestion - 每题选项数参数
+ * @returns {number} 修正后的数值
+ * - 不传/undefined → 默认3
+ * - -1 或 null → 返回 -1（表示返回全部选项）
+ * - 非正整数（含0、负数、浮点数、非数字，-1除外） → 重置为3
+ * - 正整数 < 3 → 重置为3
+ * - 正整数 >= 3 → 保持原值
+ */
+function sanitizeOptions(optionsPerQuestion) {
+  // 未传参时使用默认值
+  if (optionsPerQuestion === undefined) {
+    return 3
+  }
+
+  // null 或 -1 表示返回全部选项
+  if (optionsPerQuestion === null || optionsPerQuestion === -1) {
+    return -1
+  }
+
+  // 判断是否为正整数（排除非数字、Infinity、浮点数等）
+  if (typeof optionsPerQuestion !== 'number' || !Number.isFinite(optionsPerQuestion) || !Number.isInteger(optionsPerQuestion) || optionsPerQuestion <= 0) {
+    return 3
+  }
+
+  // 正整数但小于3，重置为最低值3
+  if (optionsPerQuestion < 3) {
+    return 3
+  }
+
+  return optionsPerQuestion
+}
+
+/**
+ * MBTI题目服务类
+ * 提供随机题目获取、参数校验、缓存管理等功能
+ */
+class QuestionService {
+  /**
+   * 构造函数，初始化缓存容器和缓存过期时间
+   */
+  constructor() {
+    /** @type {Map<string, {data: Object, timestamp: number}>} 缓存容器 */
+    this._cache = new Map()
+    /** @type {number} 缓存有效期，5分钟 */
+    this._CACHE_TTL = 5 * 60 * 1000
+  }
+
+  /**
+   * 统一参数验证入口
+   * @param {Object} [params={}] - 请求参数
+   * @param {number} [params.count] - 题目数量
+   * @param {number} [params.optionsPerQuestion] - 每题选项数
+   * @param {string|null} [params.category] - 题目分类
+   * @returns {Object} 验证结果
+   * - 验证失败：{ error: { code: 'INVALID_COUNT', message: '...' } }
+   * - 验证通过：{ count, optionsPerQuestion, category }
+   */
+  _sanitizeParams(params = {}) {
+    // 校验 count 参数
+    const count = sanitizeCount(params.count)
+    // count 为 null 说明正整数小于3，应报错
+    if (count === null) {
+      return {
+        error: {
+          code: 'INVALID_COUNT',
+          message: 'count必须为大于等于3的正整数'
+        }
+      }
+    }
+
+    // 校验每题选项数
+    const optionsPerQuestion = sanitizeOptions(params.optionsPerQuestion)
+
+    // 校验 category：只接受 string 或 null，其他类型忽略
+    let category = null
+    if (typeof params.category === 'string') {
+      // 空字符串视为 null
+      category = params.category.trim() === '' ? null : params.category
+    } else if (params.category === null || params.category === undefined) {
+      category = null
+    }
+    // 其他类型（number、boolean、object等）直接忽略，保持 null
+
+    return { count, optionsPerQuestion, category }
+  }
+
+  /**
+   * 根据参数组合生成缓存键
+   * @param {Object} params - 已校验的参数
+   * @param {number} params.count - 题目数量
+   * @param {number} params.optionsPerQuestion - 每题选项数
+   * @param {string|null} params.category - 题目分类
+   * @returns {string} 缓存键，格式：count_optionsPerQuestion_category
+   */
+  _getCacheKey(params) {
+    const { count, optionsPerQuestion, category } = params
+    return `${count}_${optionsPerQuestion}_${category || 'all'}`
+  }
+
+  /**
+   * 将结果存入缓存
+   * @param {Object} params - 已校验的参数
+   * @param {Object} result - 需要缓存的结果
+   */
+  _cacheResult(params, result) {
+    const key = this._getCacheKey(params)
+    this._cache.set(key, {
+      data: result,
+      timestamp: Date.now()
+    })
+  }
+
+  /**
+   * 从缓存中获取结果，过期自动清除
+   * @param {Object} params - 已校验的参数
+   * @returns {Object|null} 缓存的结果，过期或未命中返回 null
+   */
+  _getCachedResult(params) {
+    const key = this._getCacheKey(params)
+    const cached = this._cache.get(key)
+
+    if (!cached) {
+      return null
+    }
+
+    // 检查是否超过 TTL 过期时间
+    const isExpired = Date.now() - cached.timestamp > this._CACHE_TTL
+    if (isExpired) {
+      // 过期自动清除该条缓存
+      this._cache.delete(key)
+      return null
+    }
+
+    return cached.data
+  }
+
+  /**
+   * 清空全部缓存
+   */
+  clearCache() {
+    this._cache.clear()
+  }
+
+  /**
+   * 封装微信云函数调用
+   * @param {string} name - 云函数名称
+   * @param {Object} data - 传递给云函数的参数
+   * @returns {Promise<Object>} 云函数返回的 result 字段
+   * @throws {Error} 云函数调用失败时抛出错误
+   */
+  _callCloudFunction(name, data) {
+    return wx.cloud.callFunction({
+      name,
+      data
+    }).then(res => {
+      // 返回云函数响应中的 result 字段
+      return res.result
+    })
+  }
+
+  /**
+   * 获取随机MBTI题目（主入口方法）
+   * 流程：参数验证 → 查缓存 → 调用云函数 → 缓存成功结果 → 返回
+   * @param {Object} [params={}] - 请求参数
+   * @param {number} [params.count] - 题目数量，默认5，最小3
+   * @param {number} [params.optionsPerQuestion] - 每题选项数，默认3，-1表示全部
+   * @param {string|null} [params.category] - 题目分类，null表示全部分类
+   * @returns {Promise<Object>} 返回结果
+   * - 成功：云函数返回的数据
+   * - 参数错误：{ success: false, error: { code: 'INVALID_COUNT', message: '...' } }
+   * - 网络/云函数错误：{ success: false, error: { code: 'CLOUD_FUNCTION_ERROR', message: '网络异常，请重试' } }
+   */
+  async getRandomQuestions(params = {}) {
+    // 第一步：参数验证
+    const sanitized = this._sanitizeParams(params)
+
+    // 参数验证失败（如 count < 3），提前返回错误
+    if (sanitized.error) {
+      return { success: false, error: sanitized.error }
+    }
+
+    // 第二步：查询缓存
+    const cachedResult = this._getCachedResult(sanitized)
+    if (cachedResult) {
+      return cachedResult
+    }
+
+    // 第三步：调用云函数获取题目
+    try {
+      const result = await this._callCloudFunction('getQuestions', {
+        count: sanitized.count,
+        optionsPerQuestion: sanitized.optionsPerQuestion,
+        category: sanitized.category
+      })
+
+      // 第四步：只缓存成功结果，不缓存错误
+      if (result && result.success) {
+        this._cacheResult(sanitized, result)
+      }
+
+      return result
+    } catch (err) {
+      // 云函数调用失败或超时，返回统一错误格式
+      console.error('[QuestionService] 云函数调用失败:', err)
+      return {
+        success: false,
+        error: {
+          code: 'CLOUD_FUNCTION_ERROR',
+          message: '网络异常，请重试'
+        }
+      }
+    }
+  }
+}
+
+// 单例模式导出
+const questionService = new QuestionService()
+module.exports = questionService


### PR DESCRIPTION
- 新增云函数getQuestions实现两层随机抽题及选项抽取功能
- 实现参数校验与归一化函数，确保count和optionsPerQuestion合法
- 增加云数据库分页查询工具及Fisher-Yates洗牌算法支持
- 云函数支持根据分类筛选题目及处理题库为空等异常场景
- 在前端question-service.js中封装云函数调用及缓存机制
- 提供参数验证、缓存存取及异常处理，提升调用效率和稳定性
- 缓存有效期设计为5分钟，避免重复请求提高性能
- 统一错误码和警告机制，支持参数错误及云函数异常反馈